### PR TITLE
Update comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ focus on data capturing and raw data parsing.
 
 It stands out with three key attributes:
 
-1. Fast: It parses raw data into `np.ndarray[np.complex64]` **7.25** times
-   faster than state-of-the-art packages (0.75s v.s. 5.435s).
+1. Fast: It parses raw data into `np.ndarray[np.complex64]` **2.09** times
+   faster than state-of-the-art packages (0.59s v.s. 1.239s).
 
 2. Reliable: It makes users easily identify and debug hardware issues,
    and provides fine-grained control over different hardware.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,7 @@ Welcome to Millimeter-wave Capture Standard (mmwave-capture-std)'s documentation
 
 It stands out with three key attributes:
 
-#. **Fast**: It parses raw data into ``np.ndarray[np.complex64]`` 7.25 times faster than state-of-the-art packages (0.75s v.s. 5.435s).
+#. **Fast**: It parses raw data into ``np.ndarray[np.complex64]`` 2.09 times faster than state-of-the-art packages (0.593s v.s. 1.239s).
 
 #. **Reliable**: It makes users easily identify and debug hardware issues, and provides fine-grained control over different hardware. It achieves this by comprehensive logging (stderr & file) and by separating the hardware setup from the data capture code.
 


### PR DESCRIPTION
The difference could be my computer memory usage. After I reboot my computer with low memory usage, I cannot reproduce the original result:

```bash
Total time: 5.4347 s
File: test.py
Function: test_get_raw_data at line 76

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    76                                           @profile
    77                                           def test_get_raw_data(pcap):
    78         1     345845.1 345845.1      6.4      pcap.fetch_packets()
    79         1     373733.9 373733.9      6.9      raw_data = pcap.get_raw_data(4098)
    80         1         12.2     12.2      0.0      v = np.frombuffer(raw_data, dtype=np.int16)
    81         1    4715107.7 4715107.7     86.8      return convert(v)

Total time: 0.74961 s
File: test.py
Function: test_dca_fetch_packets at line 84

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    84                                           @profile
    85                                           def test_dca_fetch_packets(pcap):
    86         1          0.7      0.7      0.0      data_ports = [4098]
    87         1     444391.0 444391.0     59.3      pcap.dca_fetch_packets(data_ports)
    88                                           
    89         1          2.3      2.3      0.0      for port in data_ports:
    90         1         10.3     10.3      0.0          dd = pcap.get_dca_data(port)
    91         1         27.0     27.0      0.0          print(dd.is_out_of_order)
    92         1          5.6      5.6      0.0          print(dd.dca_report_tx_bytes == dd.received_rx_bytes)
    93         1          3.3      3.3      0.0          print(dd.max_seq_id)
    94         1     305148.4 305148.4     40.7          dd.convert_complex(True)
    95         1         14.4     14.4      0.0          v = np.array(dd, copy=False)
    96                                           
    97         1          6.5      6.5      0.0          v = v.reshape((-1, 64, 3, 4, 256))
    98         1          0.9      0.9      0.0          return v
```

Reboot result:

```
Total time: 1.63463 s
File: performance_test.py
Function: test_get_raw_data at line 75

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    75                                           @profile
    76                                           def test_get_raw_data(pcap):
    77         1     318656.9 318656.9     19.5      pcap.fetch_packets()
    78         1     225331.0 225331.0     13.8      raw_data = pcap.get_raw_data(4098)
    79         1         11.5     11.5      0.0      v = np.frombuffer(raw_data, dtype=np.int16)
    80         1    1090628.4 1090628.4     66.7      return convert(v)

Total time: 0.592608 s
File: performance_test.py
Function: test_dca_fetch_packets at line 83

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
    83                                           @profile
    84                                           def test_dca_fetch_packets(pcap):
    85         1          0.7      0.7      0.0      data_ports = [4098]
    86         1     389017.1 389017.1     65.6      pcap.dca_fetch_packets(data_ports)
    87                                           
    88         1          1.9      1.9      0.0      for port in data_ports:
    89         1          8.3      8.3      0.0          dd = pcap.get_dca_data(port)
    90         1         23.7     23.7      0.0          print(dd.is_out_of_order)
    91         1          4.5      4.5      0.0          print(dd.dca_report_tx_bytes == dd.received_rx_bytes)
    92         1          1.9      1.9      0.0          print(dd.max_seq_id)
    93         1     203522.5 203522.5     34.3          dd.convert_complex(True)
    94         1         19.4     19.4      0.0          v = np.array(dd, copy=False, dtype=np.complex64)
    95                                           
    96         1          7.3      7.3      0.0          v = v.reshape((-1, 64, 3, 4, 256))
    97         1          0.6      0.6      0.0          return v

Total time: 1.23988 s
File: performance_test.py
Function: test_bin_file at line 100

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   100                                           @profile
   101                                           def test_bin_file(bin_file):
   102         1     145767.6 145767.6     11.8      v = np.fromfile(bin_file, dtype=np.int16)
   103         1    1094114.2 1094114.2     88.2      return convert(v)
```