### PR TITLE
Fix DCA1000EVM capture value error

### DIFF
--- a/src/mmwavecapture/capture/radardca.py
+++ b/src/mmwavecapture/capture/radardca.py
@@ -119,8 +119,8 @@ class RadarDCA(CaptureHardware):
             raise RuntimeError(f"DCA1000EVM connection error at {self._dca_ip}")
 
         # Initialize DCA1000EVM
-        self.dca.reset_fpga()
         self.dca.reset_radar()
+        self.dca.reset_fpga()
         self.dca.config_fpga()
         self.dca.config_packet_delay()
 


### PR DESCRIPTION
The sequence of reset hardware is important. It
must reset radar first, and then reset FPGA.

Otherwise DCA1000EVM will capture garbage value.