### PR TITLE
Fix tcpdump not start causing packet lost

### DIFF
--- a/src/mmwavecapture/capture/radardca.py
+++ b/src/mmwavecapture/capture/radardca.py
@@ -33,6 +33,7 @@
 
 from __future__ import annotations
 
+import time
 import pathlib
 import signal
 import subprocess
@@ -183,6 +184,9 @@ class RadarDCA(CaptureHardware):
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
+
+        # Wait tcpdump to start capture
+        time.sleep(0.1)  # XXX: Another constant?
 
         # Start DCA1000EVM
         self.dca.start_record()


### PR DESCRIPTION
So `tcpdump` hasn't started yet, but the radar
start to sensing. This cause packet lost for pcap files.

Test the fix for 50 captures:

```bash
$ for i in {1..50}; do poetry run mmwavecapture-std configs/capture_manager.toml; done
$ poetry run python examples/pcap_check.py dataset
capture_00000 True
capture_00001 True
capture_00002 True
capture_00003 True
capture_00004 True
capture_00005 True
capture_00006 True
capture_00007 True
capture_00008 True
capture_00009 True
...
capture_00050 True
```